### PR TITLE
BUG: Drive letter is ignored on save file

### DIFF
--- a/UI/FileMenu.gd
+++ b/UI/FileMenu.gd
@@ -173,8 +173,8 @@ func reload() -> bool:
 func _on_save():
 	file_dialog_node.mode = FileDialog.MODE_SAVE_FILE
 	file_dialog_node.popup()
-	yield(file_dialog_node, "file_selected")
-	save_file(file_dialog_node.current_path)
+	var filename = yield(file_dialog_node, "file_selected")
+	save_file(filename)
 	
 func save_file(file_path: String):
 	print_debug("Saving file ", file_path)


### PR DESCRIPTION
FileDialog.file_selected does not contain the selected drive letter. If you select another drive on save it will obviously save relative to the application dir. But the file_selected signal holds the complete path as return value. Added a local variable to store the return value of the signal and use it as parameter for save_file().