### PR TITLE
Hotfix: Clears list when hiding enemies

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -264,6 +264,7 @@ static func _get_center(parent: Node2D) -> Vector2:
 
 func _on_tab_tab_changed(tab):
 	SelectedListManager.clear_list()
+	SelectedListManager.close_details_panel()
 	for i in range(tab_and_map_node.size()):
 		var map_node: Node2D = tab_and_map_node[i]
 		if map_node != null:

--- a/Main.gd
+++ b/Main.gd
@@ -264,7 +264,6 @@ static func _get_center(parent: Node2D) -> Vector2:
 
 func _on_tab_tab_changed(tab):
 	SelectedListManager.clear_list()
-	SelectedListManager.close_details_panel()
 	for i in range(tab_and_map_node.size()):
 		var map_node: Node2D = tab_and_map_node[i]
 		if map_node != null:

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -58,10 +58,8 @@ func remove_placemark(placemark, data):
 	toggle_selection(placemark, data)
 	close_details_panel()
 
-func close_details_panel():
-	print(\"the list:\", selected_list)
+func close_details_panel(): # Closes the details panel if the list is empty
 	if selected_list.size() <= 0:
-		print(\"checking\")
 		emit_signal(\"closed_detailspanel\")
 "
 

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -20,15 +20,15 @@ func toggle_selection(placemark: GenericPlacemark, data: Object):
 
 	var index = _find_entry_index(placemark)
 	if index != -1:
-		remove_from_selection(index)
+		_remove_from_selection(index)
 	else:
-		add_to_selection(entry)
+		_add_to_selection(entry)
 
-func add_to_selection(entry):
+func _add_to_selection(entry):
 	selected_list.append(entry)
 	emit_signal(\"selection_changed\")
 	
-func remove_from_selection(index):
+func _remove_from_selection(index):
 	selected_list.remove(index)
 	emit_signal(\"selection_changed\")
 	
@@ -64,7 +64,7 @@ func remove_placemark(placemark, data):
 	var entry = {\"placemark\": placemark, \"data\": data}
 	var index = _find_entry_index(placemark)
 	if index != -1:
-		remove_from_selection(index)
+		_remove_from_selection(index)
 
 func is_list_empty() -> bool:
 	return selected_list.size() <= 0

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -20,11 +20,18 @@ func toggle_selection(placemark: GenericPlacemark, data: Object):
 
 	var index = _find_entry_index(placemark)
 	if index != -1:
-		selected_list.remove(index)
+		remove_from_selection(index)
 	else:
-		selected_list.append(entry)
-	emit_signal(\"selection_changed\")
+		add_to_selection(entry)
 
+func add_to_selection(entry):
+	selected_list.append(entry)
+	emit_signal(\"selection_changed\")
+	
+func remove_from_selection(index):
+	selected_list.remove(index)
+	emit_signal(\"selection_changed\")
+	
 # Function to find the index of an entry in the list
 func _find_entry_index(placemark: GenericPlacemark) -> int:
 	for i in range(selected_list.size()):
@@ -54,11 +61,10 @@ func reveal_hidden():
 	emit_signal(\"set_revealed_hidden\")
 	
 func remove_placemark(placemark, data):
-	toggle_selection(placemark, data)
-
-func close_details_panel(): # Closes the details panel if the list is empty
-	if selected_list.size() <= 0:
-		print(\"something is still calling this\")
+	var entry = {\"placemark\": placemark, \"data\": data}
+	var index = _find_entry_index(placemark)
+	if index != -1:
+		remove_from_selection(index)
 
 func is_list_empty() -> bool:
 	return selected_list.size() <= 0

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -48,11 +48,6 @@ func delete_selected():
 			var index_to_remove = _find_entry_index(placemark)
 			if index_to_remove != -1:
 				selected_list.remove(index_to_remove)
-
-func unselected_removal(placemark: GenericPlacemark, data: Object):
-	var entry = {\"placemark\": placemark, \"data\": data}
-	var index = _find_entry_index(placemark)
-	selected_list.append(entry)
 	
 func reveal_hidden():
 	emit_signal(\"set_revealed_hidden\")

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -7,7 +7,6 @@ script/source = "extends Node
 var selected_list = []
 signal selection_changed
 signal set_revealed_hidden
-signal closed_detailspanel
 
 # Function to apply values to selected enemy or item
 func apply_values_to_selected_type(parameter_name: String, parameter_value):
@@ -49,18 +48,20 @@ func delete_selected():
 			var index_to_remove = _find_entry_index(placemark)
 			if index_to_remove != -1:
 				selected_list.remove(index_to_remove)
-				close_details_panel()
+				emit_signal(\"selection_changed\")
 	
 func reveal_hidden():
 	emit_signal(\"set_revealed_hidden\")
 	
 func remove_placemark(placemark, data):
 	toggle_selection(placemark, data)
-	close_details_panel()
 
 func close_details_panel(): # Closes the details panel if the list is empty
 	if selected_list.size() <= 0:
-		emit_signal(\"closed_detailspanel\")
+		print(\"something is still calling this\")
+
+func is_list_empty() -> bool:
+	return selected_list.size() <= 0
 "
 
 [node name="SelectedListManager" type="Node"]

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -7,6 +7,7 @@ script/source = "extends Node
 var selected_list = []
 signal selection_changed
 signal set_revealed_hidden
+signal closed_detailspanel
 
 # Function to apply values to selected enemy or item
 func apply_values_to_selected_type(parameter_name: String, parameter_value):
@@ -48,9 +49,20 @@ func delete_selected():
 			var index_to_remove = _find_entry_index(placemark)
 			if index_to_remove != -1:
 				selected_list.remove(index_to_remove)
+				close_details_panel()
 	
 func reveal_hidden():
 	emit_signal(\"set_revealed_hidden\")
+	
+func remove_placemark(placemark, data):
+	toggle_selection(placemark, data)
+	close_details_panel()
+
+func close_details_panel():
+	print(\"the list:\", selected_list)
+	if selected_list.size() <= 0:
+		print(\"checking\")
+		emit_signal(\"closed_detailspanel\")
 "
 
 [node name="SelectedListManager" type="Node"]

--- a/UI/Marker/GenericPlacemark.gd
+++ b/UI/Marker/GenericPlacemark.gd
@@ -20,7 +20,7 @@ func _gui_input(event):
 
 func _selection_function(type):
 	if Input.is_key_pressed(KEY_SHIFT):
-		SelectedListManager.toggle_selection(self, type)  # Pass EnemyPlacemark instance and enemy data
+		SelectedListManager.toggle_selection(self, type)  # Pass Enemy or Gathering Placemark instance and its data
 	else:
 		SelectedListManager.clear_list()
 		SelectedListManager.toggle_selection(self, type)

--- a/UI/Marker/GenericSetPlacemark.gd
+++ b/UI/Marker/GenericSetPlacemark.gd
@@ -17,6 +17,14 @@ func _to_hide():
 	self.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_apply_mouse_filter_to_children(self, Control.MOUSE_FILTER_IGNORE)
 
+	for child in get_children():
+		for grandchild in child.get_children():
+			for grandgrandchild in grandchild.get_children():
+				if grandgrandchild.name == "SelectionPanel" and grandgrandchild.visible:
+					var placemark = grandgrandchild.get_parent()
+					SelectedListManager.remove_placemark(placemark, null)
+					placemark.emit_signal("selection_changed")
+
 func _to_unhide():
 	self.modulate = Color(1, 1, 1, 1)  # Raising the transparency to 100%
 	self.mouse_filter = Control.MOUSE_FILTER_PASS

--- a/UI/UI.tscn
+++ b/UI/UI.tscn
@@ -34,7 +34,6 @@ func _input(event):
 	if event is InputEventKey:
 		if Input.is_action_pressed(\"set_hide\"):
 			if hovered_placemark:
-				SelectedListManager.clear_list()
 				hovered_placemark._to_hide()
 
 		if Input.is_action_just_pressed(\"set_unhide\"):
@@ -92,6 +91,7 @@ func _on_SettingsButton_pressed():
 script/source = "extends PanelContainer
 
 func _ready():
+	SelectedListManager.connect(\"closed_detailspanel\", self, \"_on_Close_pressed\")
 	visible = false
 
 func _on_Close_pressed():

--- a/UI/UI.tscn
+++ b/UI/UI.tscn
@@ -34,6 +34,7 @@ func _input(event):
 	if event is InputEventKey:
 		if Input.is_action_pressed(\"set_hide\"):
 			if hovered_placemark:
+				SelectedListManager.clear_list()
 				hovered_placemark._to_hide()
 
 		if Input.is_action_just_pressed(\"set_unhide\"):

--- a/UI/UI.tscn
+++ b/UI/UI.tscn
@@ -91,13 +91,17 @@ func _on_SettingsButton_pressed():
 script/source = "extends PanelContainer
 
 func _ready():
-	SelectedListManager.connect(\"closed_detailspanel\", self, \"_on_Close_pressed\")
+	SelectedListManager.connect(\"selection_changed\", self, \"_on_selection_changed\")
 	visible = false
+
+func _on_selection_changed():
+	if SelectedListManager.selected_list.size() == 0:
+		visible = false
 
 func _on_Close_pressed():
 	SelectedListManager.clear_list()
 	visible = false
-	
+
 func _on_DetailsPanel_showing_details_of(obj):
 	visible = obj != null
 "

--- a/resources/internationalization/enemy_name.csv
+++ b/resources/internationalization/enemy_name.csv
@@ -259,7 +259,7 @@ NAME_0x015052,Frost Skeleton Cyclops,スケルトンサイクロプス・フロ�
 NAME_0x015053,Bolt Skeleton Cyclops,スケルトンサイクロプス・ボルト
 NAME_0x015054,Flame Skeleton Cyclops,スケルトンサイクロプス・フレイム
 NAME_0x015060,War-Ready Gorecyclops (Light Armor),戦甲ゴアサイクロプス・軽装
-NAME_0x015061,War-Ready Gorecyclops (Light Armor),戦甲ゴアサイクロプス・軽装
+NAME_0x015061,War-Ready Gorecyclops (Light Armor)-(Named Goblin),戦甲ゴアサイクロプス・軽装・ゴブリン
 NAME_0x015100,Golem,ゴーレム
 NAME_0x015102,Goliath,ゴリアテ
 NAME_0x015103,Damned Golem,ダムドゴーレム


### PR DESCRIPTION
A quick hotfix to prevent altering or removing selected nodes if you hid them, it calls clear_list when you attempt to hide something, effectively acting as a pseudo de-select button

also removed the function "unselected removal" from selected list manager since it no longer gets called 👍 

adjusted duplicate WR-GC to indicate its odd naming ingame, I think it might be a missing entry in ENEMY_NAME_X in the server code, but I have no idea how any of that works, 🤔 and I can't see how we assign an enemy to a name, so this is the solution I've taken lol
![image](https://github.com/alborrajo/DDOn-Tools/assets/42190924/a783f9f2-6155-4542-9f34-aa7043ae802b)

(this name update is also reflected in the Japanese)


Small UX addition, when nothing is selected it will close the details tab instead of displaying a blank one.