### PR TITLE
HotFix: Mismatching Placemark types now ClearsList

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -263,7 +263,6 @@ static func _get_center(parent: Node2D) -> Vector2:
 
 
 func _on_tab_tab_changed(tab):
-	SelectedListManager.clear_list()
 	for i in range(tab_and_map_node.size()):
 		var map_node: Node2D = tab_and_map_node[i]
 		if map_node != null:

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -5,6 +5,8 @@ resource_name = "SelectedListManager"
 script/source = "extends Node
 
 var selected_list = []
+var enemy_type = false
+var item_type = false
 signal selection_changed
 signal set_revealed_hidden
 
@@ -17,6 +19,16 @@ func apply_values_to_selected_type(parameter_name: String, parameter_value):
 # Function to check the list for type and removes if it exists already
 func toggle_selection(placemark: GenericPlacemark, data: Object):
 	var entry = {\"placemark\": placemark, \"data\": data}
+	
+	if placemark is EnemyPlacemark:
+		enemy_type = true
+		
+	if placemark is GatheringItemPlacemark:
+		item_type = true
+		
+	if enemy_type and item_type:
+		clear_list()
+		print(\"we mismatched, cleaning up!\")
 
 	var index = _find_entry_index(placemark)
 	if index != -1:

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -55,6 +55,8 @@ func _find_entry_index(placemark: GenericPlacemark) -> int:
 func clear_list():
 	selected_list.clear()
 	emit_signal(\"selection_changed\")
+	enemy_type = false
+	item_type = false
 
 # Function that handles the deletion of multiple placemarks.
 # Handle the list in reverse order to ensure it doesn't trip over any indexes and fail to delete entries

--- a/Providers/SelectedListManager.tscn
+++ b/Providers/SelectedListManager.tscn
@@ -28,7 +28,6 @@ func toggle_selection(placemark: GenericPlacemark, data: Object):
 		
 	if enemy_type and item_type:
 		clear_list()
-		print(\"we mismatched, cleaning up!\")
 
 	var index = _find_entry_index(placemark)
 	if index != -1:


### PR DESCRIPTION
Critical issue in latest release where you can't assign drops to a loot table because changing tabs cleared the list (which closed the details panel)

Now I no longer clear the list on tab change, but when you mismatch placemark types.