### PR TITLE
Update GatheringItem.gd to change default drop chance.

### DIFF
--- a/Entities/GatheringItem.gd
+++ b/Entities/GatheringItem.gd
@@ -12,7 +12,7 @@ func _init(_item: Item):
 	self.item = _item
 	self.num = 1
 	self.max_num = 1
-	self.drop_chance = 1
+	self.drop_chance = 100
 
 func get_display_name() -> String:
 	return "%s (%d~%d)" % [item.name, num, max_num]


### PR DESCRIPTION
- Changed self.drop_chance in GatheringItem.gd so when loading old csv's or when adding new items to existing csv's, the default drop chance for the item comes as 100% intead of 1%.