### PR TITLE
Can now use UI to specify PP in EnemySpawn files

### DIFF
--- a/Entities/Enemy.gd
+++ b/Entities/Enemy.gd
@@ -155,6 +155,7 @@ var blood_orbs: int = 0 setget _set_blood_orbs
 var is_highorb_enemy: bool = false setget _set_is_highorb_enemy
 var high_orbs: int = 0 setget _set_high_orbs
 var experience: int = 0 setget _set_experience
+var play_points: int = 0 setget _set_play_points
 var drops_table: DropsTable = null setget _set_drops_table
 
 func _init(type: EnemyType, np: NamedParam = null):
@@ -193,6 +194,7 @@ func clone() -> Enemy:
 	new_enemy.is_highorb_enemy = self.is_highorb_enemy
 	new_enemy.high_orbs = self.high_orbs
 	new_enemy.experience = self.experience
+	new_enemy.play_points = self.play_points
 	new_enemy.drops_table = self.drops_table
 	return new_enemy
 
@@ -306,6 +308,10 @@ func _set_high_orbs(value):
 	
 func _set_experience(value):
 	experience = value
+	emit_changed()
+
+func _set_play_points(value):
+	play_points = value
 	emit_changed()
 
 func _set_drops_table(value):

--- a/UI/EnemyDetailsPanel.gd
+++ b/UI/EnemyDetailsPanel.gd
@@ -66,6 +66,8 @@ func _on_enemy_changed():
 		$VBoxContainer/GridContainer/HighOrbsContainer/HighOrbsSpinBox.value = enemy_clone.high_orbs
 		$VBoxContainer/ExpContainer/NamedParamsExpPercentageLabel.text = String(enemy_clone.named_param.experience)
 		$VBoxContainer/ExpContainer/ExpSpinBox.value = enemy_clone.experience
+		$VBoxContainer/PpContainer/NamedParamsPpPercentageLabel.text = String(enemy_clone.play_points)
+		$VBoxContainer/PpContainer/PpSpinBox.value = enemy_clone.play_points
 		_refresh_selected_name()
 		if enemy_clone.drops_table == null:
 			$VBoxContainer/DropsController.select_drops_table(-1, true)
@@ -206,6 +208,12 @@ func _on_ExpSpinBox_value_changed(value):
 	enemy.experience = int(value)
 	if supress_event != true:
 		SelectedListManager.apply_values_to_selected_type("experience", enemy.experience)
+
+func _on_PpSpinBox_value_changed(value):
+	enemy.play_points = int(value)
+	if supress_event != true:
+		SelectedListManager.apply_values_to_selected_type("play_points", enemy.play_points)
+
 
 func _on_DropsContainer_drops_table_selected(drops_table):
 	enemy.drops_table = drops_table

--- a/UI/EnemyDetailsPanel.tscn
+++ b/UI/EnemyDetailsPanel.tscn
@@ -22,7 +22,7 @@ script = ExtResource( 3 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 1004.0
-margin_bottom = 732.0
+margin_bottom = 764.0
 size_flags_horizontal = 3
 
 [node name="NamedParamsControl" type="VBoxContainer" parent="VBoxContainer"]
@@ -375,15 +375,42 @@ size_flags_horizontal = 3
 max_value = 4.29497e+09
 suffix = "XP"
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="PpContainer" type="HFlowContainer" parent="VBoxContainer"]
 margin_top = 564.0
 margin_right = 1004.0
-margin_bottom = 568.0
+margin_bottom = 592.0
+hint_tooltip = "Named Params can affect the play points dropped"
 
-[node name="DropsFilterLineEdit" type="LineEdit" parent="VBoxContainer"]
-margin_top = 572.0
+[node name="NamedParamsPpPercentageLabel" type="Label" parent="VBoxContainer/PpContainer"]
+margin_top = 5.0
+margin_right = 21.0
+margin_bottom = 23.0
+text = "100"
+
+[node name="PpPercentageLabel" type="Label" parent="VBoxContainer/PpContainer"]
+margin_left = 25.0
+margin_top = 5.0
+margin_right = 50.0
+margin_bottom = 23.0
+text = "% of"
+
+[node name="PpSpinBox" type="SpinBox" parent="VBoxContainer/PpContainer"]
+margin_left = 54.0
+margin_right = 1004.0
+margin_bottom = 28.0
+size_flags_horizontal = 3
+max_value = 4.29497e+09
+suffix = "PP"
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+margin_top = 596.0
 margin_right = 1004.0
 margin_bottom = 600.0
+
+[node name="DropsFilterLineEdit" type="LineEdit" parent="VBoxContainer"]
+margin_top = 604.0
+margin_right = 1004.0
+margin_bottom = 632.0
 size_flags_horizontal = 3
 clear_button_enabled = true
 right_icon = ExtResource( 6 )
@@ -393,9 +420,9 @@ __meta__ = {
 }
 
 [node name="DropsController" type="VBoxContainer" parent="VBoxContainer"]
-margin_top = 604.0
+margin_top = 636.0
 margin_right = 1004.0
-margin_bottom = 732.0
+margin_bottom = 764.0
 script = ExtResource( 4 )
 
 [node name="HFlowContainer" type="HFlowContainer" parent="VBoxContainer/DropsController"]
@@ -505,6 +532,9 @@ margin_bottom = 86.0
 [connection signal="pressed" from="VBoxContainer/GridContainer/HighOrbsContainer/IsHighOrbEnemy" to="." method="_on_IsHighOrbEnemy_pressed"]
 [connection signal="value_changed" from="VBoxContainer/GridContainer/HighOrbsContainer/HighOrbsSpinBox" to="." method="_on_HighOrbsSpinBox_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/ExpContainer/ExpSpinBox" to="." method="_on_ExpSpinBox_value_changed"]
+[connection signal="changed" from="VBoxContainer/PpContainer/PpSpinBox" to="." method="_on_PpSpinBox_changed"]
+[connection signal="focus_entered" from="VBoxContainer/PpContainer/PpSpinBox" to="." method="_on_PpSpinBox_focus_entered"]
+[connection signal="value_changed" from="VBoxContainer/PpContainer/PpSpinBox" to="." method="_on_PpSpinBox_value_changed"]
 [connection signal="text_changed" from="VBoxContainer/DropsFilterLineEdit" to="VBoxContainer/DropsController" method="_on_DropsFilterLineEdit_text_changed"]
 [connection signal="drops_table_selected" from="VBoxContainer/DropsController" to="." method="_on_DropsContainer_drops_table_selected"]
 [connection signal="item_selected" from="VBoxContainer/DropsController/HFlowContainer/DropsTableOptionButton" to="VBoxContainer/DropsController" method="_on_DropsTableOptionButton_item_selected"]

--- a/UI/EnemyFileMenu.gd
+++ b/UI/EnemyFileMenu.gd
@@ -58,6 +58,7 @@ const ENEMIES_SCHEMA := PoolStringArray([
 	"Experience",
 	"DropsTableId",
 	"SpawnTime",
+	"PPDrop"
 ])
 
 const DROPS_TABLE_ITEMS_SCHEMA := PoolStringArray([
@@ -185,6 +186,11 @@ func _do_load_file_json(file: File) -> int:
 		enemy.high_orbs = data[enemies_schema_idx["HighOrbs"]]
 		enemy.is_highorb_enemy = enemy.high_orbs > 0
 		enemy.experience = data[enemies_schema_idx["Experience"]]
+		# The PPDrop field may or may not exist. If it doesn't exist, set to Experience over 7500
+		if enemies_schema_idx.has("PPDrop"):
+			enemy.play_points = data[enemies_schema_idx["PPDrop"]]
+		else:
+			enemy.play_points = enemy.experience / 7500
 
 		var drops_table_id = data[enemies_schema_idx["DropsTableId"]]
 		if drops_table_id == -1:
@@ -354,6 +360,8 @@ func _do_save_file(file: File) -> void:
 			if selected_index == 3:
 				selected_string = enemy.custom_time
 			data.append(selected_string)
+
+			data.append(enemy.play_points)
 
 			json_data[JSON_KEY_ENEMIES].append(data)
 

--- a/UI/UI.tscn
+++ b/UI/UI.tscn
@@ -160,6 +160,7 @@ margin_bottom = 544.0
 tab_align = 0
 
 [node name="Stages" type="Control" parent="left/tab"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -187,7 +188,6 @@ size_flags_vertical = 3
 script = ExtResource( 19 )
 
 [node name="Enemies" type="VBoxContainer" parent="left/tab"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -478,7 +478,7 @@ margin_top = -195.0
 margin_right = 312.0
 margin_bottom = 195.0
 rect_min_size = Vector2( 180, 63 )
-window_title = "Abrir un Archivo"
+window_title = "Open a File"
 mode = 0
 access = 2
 filters = PoolStringArray( "*.json; JSON Files", "*.csv ; CSV Files" )
@@ -494,7 +494,7 @@ margin_top = -195.0
 margin_right = 312.0
 margin_bottom = 195.0
 rect_min_size = Vector2( 180, 63 )
-window_title = "Abrir un Archivo"
+window_title = "Open a File"
 mode = 0
 access = 2
 filters = PoolStringArray( "*.csv ; CSV Files" )


### PR DESCRIPTION
I have updated DDOn-Tools so that the user specifies a number of Play Points (PP) an enemy has explicitly. In the case of loading a file where this is not specified, DDOn-Tools will automatically populate the field with the enemy's EXP / 7500, which is the default used by enemies currently, and then be able to save this information into the file. Therefore, the tool will automatically update any legacy files without this field to new ones without affecting usability and being completely transparent to the user. One may also specify specific numbers of play points on a per-enemy basis, which may be however large or small we desire. This may allow creation of a special PP-farming area where enemies drop heaps of PP.

Here is a screenshot taken from in-game after editing a zombie to have 5 PP (default 0) and killing it:

https://cdn.discordapp.com/attachments/596777784928632858/1291078149177868369/image.png?ex=66fec9b9&is=66fd7839&hm=04d7a288c54193c07316be9d37437f6d6e0f76020b0a55bd7fb803d6b7095e91&

I also included a default EnemySpawn.json file as an example. It has the default spawns in the standard server, with PP values all at the default.