### PR TITLE
Ignore the SubGroupNo value from the client files

### DIFF
--- a/Providers/DataProvider.gd
+++ b/Providers/DataProvider.gd
@@ -40,14 +40,14 @@ func _ready():
 			
 			# TODO: Optimize this 
 			for enemy_set in enemy_sets[stage_no]:
-				if enemy_set["GroupNo"] == enemy_position["GroupNo"] and enemy_set["SubGroupNo"] == enemy_position["SubGroupNo"]:
+				if enemy_set["GroupNo"] == enemy_position["GroupNo"]:# and enemy_set["SubGroupNo"] == enemy_position["SubGroupNo"]:
 					existing_enemy_set = enemy_set
 					break
 
 			if existing_enemy_set == null:
 				existing_enemy_set = {}
 				existing_enemy_set["GroupNo"] = enemy_position["GroupNo"]
-				existing_enemy_set["SubGroupNo"] = enemy_position["SubGroupNo"]
+				#existing_enemy_set["SubGroupNo"] = enemy_position["SubGroupNo"]
 				existing_enemy_set["Positions"] = []
 				enemy_sets[stage_no].append(existing_enemy_set)
 

--- a/Providers/SetProvider.tscn
+++ b/Providers/SetProvider.tscn
@@ -18,7 +18,7 @@ func _ready():
 			var stage_id := DataProvider.stage_no_to_stage_id(int(stage_no))
 			var layer_no := 0
 			var group_no := int(enemy_set[\"GroupNo\"])
-			var subgroup_no := int(enemy_set[\"SubGroupNo\"])
+			var subgroup_no := -1#int(enemy_set[\"SubGroupNo\"])
 			var enemy_set_instance := EnemySet.new(stage_id, layer_no, group_no)
 			var positions = []
 			for position_index in enemy_set[\"Positions\"].size():


### PR DESCRIPTION
All positions found in the client files, regardless of its SubGroupNo value, will be interpreted as positions present in all subgroups